### PR TITLE
Fix spelling errors

### DIFF
--- a/container/compass-ci-web/build
+++ b/container/compass-ci-web/build
@@ -8,7 +8,7 @@ docker_skip_rebuild "compass-ci-web"
 
 load_cci_defaults
 
-[[ $BASE_RESULT_URL ]] || BASE_RESUTL_URL='https://api.compass-ci.openeuler.org'
+[[ $BASE_RESULT_URL ]] || BASE_RESULT_URL='https://api.compass-ci.openeuler.org'
 [[ $BASE_WEB_BACKEND_URL ]] || BASE_WEB_BACKEND_URL='https://api.compass-ci.openeuler.org/web_backend'
 
 if [ -d "./crystal-ci" ]; then
@@ -16,7 +16,7 @@ if [ -d "./crystal-ci" ]; then
 fi
 
 git clone https://gitee.com/theprocess/crystal-ci
-sed -i "s#export const BASEURLRESULT = 'https://api.compass-ci.openeuler.org';#export const BASEURLRESULT = '$BASE_RESUTL_URL';#g" ./crystal-ci/src/utils/baseUrl.js
+sed -i "s#export const BASEURLRESULT = 'https://api.compass-ci.openeuler.org';#export const BASEURLRESULT = '$BASE_RESULT_URL';#g" ./crystal-ci/src/utils/baseUrl.js
 sed -i "s#const BASEURL = 'https://api.compass-ci.openeuler.org/web_backend';#export const BASEURL = '$BASE_WEB_BACKEND_URL';#g" ./crystal-ci/src/utils/axios.utils.js
 
 


### PR DESCRIPTION
A misspelling that causes the jump link to not take effect when the web page views the job result after local deployment